### PR TITLE
ordinality: add support for ordinalty; first unit tests!!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+- 1.7.4
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+before_install: go get -u github.com/Masterminds/glide
+install: glide install
+script: go test -v $(glide novendor) -check.vv

--- a/humanize_test.go
+++ b/humanize_test.go
@@ -1,0 +1,13 @@
+package humanize_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }

--- a/numbers.go
+++ b/numbers.go
@@ -1,0 +1,50 @@
+package humanize
+
+import "fmt"
+
+var ords = []string{"th", "st", "nd", "rd"}
+
+func abs(i int64) uint64 {
+	if i < 0 {
+		return uint64(i * -1)
+	}
+
+	return uint64(i)
+}
+
+func ordinality(i uint64) string {
+	// numbers like 211, 212, and 213 are special
+	if v := i % 100; v == 11 || v == 12 || v == 13 {
+		return ords[0]
+	}
+
+	if lastNum := i % 10; lastNum < 4 {
+		return ords[lastNum]
+	}
+
+	return ords[0]
+}
+
+// OrdinalInt is a function that takes an int and returns a string with its
+// ordinal value. For example, 2 would become "2nd".
+func OrdinalInt(i int) string {
+	return fmt.Sprintf("%d%s", i, ordinality(abs(int64(i))))
+}
+
+// OrdinalInt64 is a function that takes an int64 and returns a string with its
+// ordinal value. For example, 3 would become "3rd".
+func OrdinalInt64(i int64) string {
+	return fmt.Sprintf("%d%s", i, ordinality(abs(i)))
+}
+
+// OrdinalUint is a function that takes an uint and returns a string with its
+// ordinal value. For example, 4 would become "4th".
+func OrdinalUint(i uint) string {
+	return fmt.Sprintf("%d%s", i, ordinality(uint64(i)))
+}
+
+// OrdinalUint64 is a function that takes an uint64 and returns a string with its
+// ordinal value. For example, 42 would become "42nd".
+func OrdinalUint64(i uint64) string {
+	return fmt.Sprintf("%d%s", i, ordinality(i))
+}

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -1,0 +1,132 @@
+package humanize_test
+
+import (
+	"github.com/theckman/humanize-go"
+	. "gopkg.in/check.v1"
+)
+
+func (*TestSuite) TestOrdinalInt(c *C) {
+	var human string
+
+	tests := []struct {
+		i int
+		r string
+	}{
+		{i: 0, r: "0th"},
+		{i: 1, r: "1st"},
+		{i: 2, r: "2nd"},
+		{i: 3, r: "3rd"},
+		{i: 4, r: "4th"},
+		{i: 5, r: "5th"},
+		{i: 6, r: "6th"},
+		{i: 7, r: "7th"},
+		{i: 8, r: "8th"},
+		{i: 9, r: "9th"},
+		{i: 11, r: "11th"},
+		{i: 12, r: "12th"},
+		{i: 13, r: "13th"},
+		{i: 111, r: "111th"},
+		{i: 212, r: "212th"},
+		{i: 313, r: "313th"},
+		{i: -13, r: "-13th"},
+	}
+
+	for _, test := range tests {
+		human = humanize.OrdinalInt(test.i)
+		c.Check(human, Equals, test.r)
+	}
+}
+
+func (*TestSuite) TestOrdinalInt64(c *C) {
+	var human string
+
+	tests := []struct {
+		i int64
+		r string
+	}{
+		{i: 0, r: "0th"},
+		{i: 1, r: "1st"},
+		{i: 2, r: "2nd"},
+		{i: 3, r: "3rd"},
+		{i: 4, r: "4th"},
+		{i: 5, r: "5th"},
+		{i: 6, r: "6th"},
+		{i: 7, r: "7th"},
+		{i: 8, r: "8th"},
+		{i: 9, r: "9th"},
+		{i: 11, r: "11th"},
+		{i: 12, r: "12th"},
+		{i: 13, r: "13th"},
+		{i: 111, r: "111th"},
+		{i: 212, r: "212th"},
+		{i: 313, r: "313th"},
+		{i: -13, r: "-13th"},
+	}
+
+	for _, test := range tests {
+		human = humanize.OrdinalInt64(test.i)
+		c.Check(human, Equals, test.r)
+	}
+}
+
+func (*TestSuite) TestOrdinaUint(c *C) {
+	var human string
+
+	tests := []struct {
+		i uint
+		r string
+	}{
+		{i: 0, r: "0th"},
+		{i: 1, r: "1st"},
+		{i: 2, r: "2nd"},
+		{i: 3, r: "3rd"},
+		{i: 4, r: "4th"},
+		{i: 5, r: "5th"},
+		{i: 6, r: "6th"},
+		{i: 7, r: "7th"},
+		{i: 8, r: "8th"},
+		{i: 9, r: "9th"},
+		{i: 11, r: "11th"},
+		{i: 12, r: "12th"},
+		{i: 13, r: "13th"},
+		{i: 111, r: "111th"},
+		{i: 212, r: "212th"},
+		{i: 313, r: "313th"},
+	}
+
+	for _, test := range tests {
+		human = humanize.OrdinalUint(test.i)
+		c.Check(human, Equals, test.r)
+	}
+}
+
+func (*TestSuite) TestOrdinalUint64(c *C) {
+	var human string
+
+	tests := []struct {
+		i uint64
+		r string
+	}{
+		{i: 0, r: "0th"},
+		{i: 1, r: "1st"},
+		{i: 2, r: "2nd"},
+		{i: 3, r: "3rd"},
+		{i: 4, r: "4th"},
+		{i: 5, r: "5th"},
+		{i: 6, r: "6th"},
+		{i: 7, r: "7th"},
+		{i: 8, r: "8th"},
+		{i: 9, r: "9th"},
+		{i: 11, r: "11th"},
+		{i: 12, r: "12th"},
+		{i: 13, r: "13th"},
+		{i: 111, r: "111th"},
+		{i: 212, r: "212th"},
+		{i: 313, r: "313th"},
+	}
+
+	for _, test := range tests {
+		human = humanize.OrdinalUint64(test.i)
+		c.Check(human, Equals, test.r)
+	}
+}


### PR DESCRIPTION
This change adds support for converting some number types to strings with
ordinality (e.g., 1st, 2nd, 3rd, 4th, 113th, etc.).

In addition, unit tests were added for these new functions to ensure proper
behaviors.

Signed-off-by: Tim Heckman <t@heckman.io>