### PR TITLE
add Version constant to the package

### DIFF
--- a/humanize.go
+++ b/humanize.go
@@ -1,0 +1,4 @@
+package humanize
+
+// Version is the SemVer 2.0 version for the package.
+const Version = "0.0.1"

--- a/humanize_test.go
+++ b/humanize_test.go
@@ -1,8 +1,10 @@
 package humanize_test
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/theckman/humanize-go"
 	. "gopkg.in/check.v1"
 )
 
@@ -11,3 +13,12 @@ type TestSuite struct{}
 var _ = Suite(&TestSuite{})
 
 func Test(t *testing.T) { TestingT(t) }
+
+func (*TestSuite) TestVersion(c *C) {
+	// matches:
+	// 1.2.3
+	// 1.2.4-rc1
+	reg, err := regexp.Compile(`^(?:\d+)\.(?:\d+)\.(?:\d+)(?:-[a-zA-Z0-9\.]+)?$`)
+	c.Assert(err, IsNil)
+	c.Check(reg.MatchString(humanize.Version), Equals, true)
+}


### PR DESCRIPTION
This adds the `humanize.Version` string constant, and adds a test to assert that
its format is what we'd expect for a SemVer 2.0 version string.

Signed-off-by: Tim Heckman <t@heckman.io>